### PR TITLE
会社名と役職名の訂正

### DIFF
--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "会社概要 | Smart Fluent - 全力で伴走する技術パートナー",
-  description: "Smart Fluent合同会社は、DXとAI技術を駆使して企業が実務に集中できる環境を創造します。豊富な業務効率化・技術支援の実績を活かし、全力で伴走しながらお客様の業務課題を解決します。",
+  description: "合同会社SMART FLUENTは、DXとAI技術を駆使して企業が実務に集中できる環境を創造します。豊富な業務効率化・技術支援の実績を活かし、全力で伴走しながらお客様の業務課題を解決します。",
   keywords: "会社概要, Smart Fluent, 伴走型支援, 技術パートナー, DX, AI, 業務効率化, 実績",
 };
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -113,7 +113,7 @@ export default function AboutPage() {
                   <span className="text-lg font-semibold text-brand-orange-dark">会社名</span>
                 </div>
                 <div className="md:w-3/4 md:pl-6">
-                  <span className="text-xl font-medium text-brand-black">Smart Fluent合同会社</span>
+                  <span className="text-xl font-medium text-brand-black">合同会社SMART FLUENT</span>
                 </div>
               </div>
               
@@ -180,7 +180,7 @@ export default function AboutPage() {
                 </p>
                 <div className="brand-card rounded-xl p-4 inline-block bg-white border-brand-orange/20">
                   <p className="text-2xl font-bold brand-gradient-text mb-1">林 和樹</p>
-                  <p className="text-sm text-brand-gray">代表取締役</p>
+                  <p className="text-sm text-brand-gray">代表</p>
                 </div>
               </div>
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,9 +18,9 @@ export const metadata: Metadata = {
   },
   description: "DXとAI技術を駆使して業務効率化・自動化を実現。BPO（Business Process Outsourcing）、AI活用支援、システム開発など幅広いサービスで、お客様が実務に集中できる環境づくりを全力で支援します。",
   keywords: ["BPO", "Business Process Outsourcing", "AI活用支援", "DX導入", "業務効率化", "自動化", "システム開発", "技術支援", "AI研修", "伴走型支援", "アウトソーシング"],
-  authors: [{ name: "Smart Fluent合同会社" }],
-  creator: "Smart Fluent合同会社",
-  publisher: "Smart Fluent合同会社",
+  authors: [{ name: "合同会社SMART FLUENT" }],
+  creator: "合同会社SMART FLUENT",
+  publisher: "合同会社SMART FLUENT",
   formatDetection: {
     email: false,
     address: false,

--- a/src/app/legal/privacy/page.tsx
+++ b/src/app/legal/privacy/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "プライバシーポリシー | Smart Fluent - AIで実務に集中できる環境をつくる",
-  description: "Smart Fluent合同会社のプライバシーポリシー。お客様の個人情報を適切に保護し、業務効率化・AI活用支援サービスを安心してご利用いただくための取り組みをご説明します。",
+  description: "合同会社SMART FLUENTのプライバシーポリシー。お客様の個人情報を適切に保護し、業務効率化・AI活用支援サービスを安心してご利用いただくための取り組みをご説明します。",
   robots: "noindex, nofollow", // Generally recommended for legal pages
 };
 
@@ -13,7 +13,7 @@ export default function PrivacyPolicyPage() {
       <div className="max-w-3xl mx-auto bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md border border-gray-200 dark:border-gray-700 prose dark:prose-invert lg:prose-lg">
         {/* Placeholder Content */}
         <h2>1. 基本方針</h2>
-        <p>Smart Fluent合同会社（以下、「当社」といいます。）は、個人情報の重要性を認識し、個人情報を保護することが社会的責務であると考え、個人情報に関する法令及び社内規程等を遵守し、当社で取扱う個人情報の取得、利用、管理を適正に行います。</p>
+        <p>合同会社SMART FLUENT（以下、「当社」といいます。）は、個人情報の重要性を認識し、個人情報を保護することが社会的責務であると考え、個人情報に関する法令及び社内規程等を遵守し、当社で取扱う個人情報の取得、利用、管理を適正に行います。</p>
 
         <h2>2. 適用範囲</h2>
         <p>本プライバシーポリシーは、当社が行う各種サービスにおいて、お客様の個人情報もしくはそれに準ずる情報を取り扱う際に、当社が遵守する方針を示したものです。</p>
@@ -38,7 +38,7 @@ export default function PrivacyPolicyPage() {
         <p>当社は、法令等の制定改廃や情勢の変化により、本ポリシーを適宜見直し、予告なく変更する場合があります。</p>
 
         <h2>9. お問い合わせ</h2>
-        <p>当社の個人情報の取扱に関するお問い合せは下記までご連絡ください。<br />Smart Fluent合同会社<br />（連絡先情報を記載）</p>
+        <p>当社の個人情報の取扱に関するお問い合せは下記までご連絡ください。<br />合同会社SMART FLUENT<br />（連絡先情報を記載）</p>
 
         <p>制定日：YYYY年MM月DD日</p>
       </div>

--- a/src/app/legal/terms/page.tsx
+++ b/src/app/legal/terms/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "利用規約 | Smart Fluent - AIで実務に集中できる環境をつくる",
-  description: "Smart Fluent合同会社のサービス利用規約。AI活用支援、DX導入支援、システム開発等のサービスを安心してご利用いただくための規約です。",
+  description: "合同会社SMART FLUENTのサービス利用規約。AI活用支援、DX導入支援、システム開発等のサービスを安心してご利用いただくための規約です。",
   robots: "noindex, nofollow", // Generally recommended for legal pages
 };
 
@@ -13,7 +13,7 @@ export default function TermsOfServicePage() {
       <div className="max-w-3xl mx-auto bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md border border-gray-200 dark:border-gray-700 prose dark:prose-invert lg:prose-lg">
         {/* Placeholder Content */}
         <h2>第1条（適用）</h2>
-        <p>本規約は、Smart Fluent合同会社（以下、「当社」といいます。）が提供する一切のサービス（以下、「本サービス」といいます。）の利用条件を定めるものです。ユーザーの皆様（以下、「ユーザー」といいます。）には、本規約に従って本サービスをご利用いただきます。</p>
+        <p>本規約は、合同会社SMART FLUENT（以下、「当社」といいます。）が提供する一切のサービス（以下、「本サービス」といいます。）の利用条件を定めるものです。ユーザーの皆様（以下、「ユーザー」といいます。）には、本規約に従って本サービスをご利用いただきます。</p>
 
         <h2>第2条（定義）</h2>
         <p>（ここに本規約で使用する用語の定義を記載します。）</p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = () => {
             {/* Company Info */}
             <div className="space-y-4">
               <h3 className="text-xl font-bold brand-gradient-text">
-                Smart Fluent合同会社
+                合同会社SMART FLUENT
               </h3>
               <p className="text-gray-600 text-sm leading-relaxed">
                 AIで実務に集中できる環境をつくる
@@ -75,7 +75,7 @@ const Footer = () => {
             <div className="absolute inset-x-0 top-0 h-px bg-gray-200" />
             <div className="pt-8 flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
               <p className="text-gray-600 text-sm">
-                &copy; {currentYear} Smart Fluent合同会社. All rights reserved.
+                &copy; {currentYear} 合同会社SMART FLUENT. All rights reserved.
               </p>
               <div className="flex items-center space-x-2">
                 <span className="text-gray-500 text-xs">Powered by</span>


### PR DESCRIPTION
イシュー #6 の依頼に基づき、会社名と役職名を訂正しました。

## 修正内容
- 「Smart Fluent合同会社」→「合同会社SMART FLUENT」に変更
- 「代表取締役」→「代表」に変更

## 修正したファイル
- `src/app/about/page.tsx`
- `src/app/layout.tsx`
- `src/app/legal/privacy/page.tsx`
- `src/app/legal/terms/page.tsx`
- `src/components/Footer.tsx`
- `src/app/about/layout.tsx`

Generated with [Claude Code](https://claude.ai/code)